### PR TITLE
Fix blurry images

### DIFF
--- a/style.css
+++ b/style.css
@@ -39,6 +39,8 @@ img {
   -webkit-user-drag: none;
   -webkit-user-select: none;
   -ms-user-select: none;
+  image-rendering: pixelated;
+  image-rendering: crisp-edges;
 }
 #logo {
   position: absolute;


### PR DESCRIPTION
Images are normally upscaled in a way that makes them blurry, which is bad for pixel art. I had to add a duplicate CSS property because `pixelated` works on Chrome and `crisp-edges` works on Firefox. Tested on latest Chrome and Firefox stable. If there are any images added to the site that aren't pixel art, this should be put into a more specific CSS selector to prevent them from being upscaled like pixel art (without smoothing).

This isn't a huge change but it makes the website look slightly better.